### PR TITLE
feat: Separate React and Node configs on top of base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ ESLint rules from Andrey Okonetchnikov
 ```json
 "eslintConfig": {
     "extends": [
-      "eslint-config-okonet"
+      "okonet"
     ]
   }
 ```
+
+This will add generic config.
+
+For React.js projects, extend from `okonet/react`
+
+For Node.js projects, extend from `okonet/node`

--- a/index.js
+++ b/index.js
@@ -1,20 +1,16 @@
+'use strict'
+
 module.exports = {
-  parser: 'babel-eslint',
   env: {
-    es6: true,
-    browser: true,
-    commonjs: true,
-    mocha: true,
+    es6: true, // This setting enables ES6 syntax automatically
     jest: true
   },
   extends: [
     'eslint-config-airbnb-base',
     'eslint-config-airbnb-base/rules/strict',
-    'eslint-config-airbnb/rules/react',
     'eslint-plugin-flowtype/dist/configs/recommended',
     'eslint-config-prettier',
-    'eslint-config-prettier/flowtype',
-    'eslint-config-prettier/react'
+    'eslint-config-prettier/flowtype'
   ].map(require.resolve),
   plugins: ['flowtype', 'prettier'],
   rules: {
@@ -30,18 +26,6 @@ module.exports = {
     'no-console': 2,
     'no-debugger': 2,
     'guard-for-in': 0,
-
-    // React
-    'react/jsx-filename-extension': 0,
-    'react/sort-comp': [
-      2,
-      {
-        order: ['flow-types', 'static-methods', 'lifecycle', 'everything-else', 'render'],
-        groups: {
-          'flow-types': ['props', 'state']
-        }
-      }
-    ],
 
     // Import
     'import/no-extraneous-dependencies': [

--- a/node.js
+++ b/node.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  parserOptions: {
+    sourceType: 'script'
+  },
+  env: {
+    node: true
+  },
+  plugins: ['node'],
+  extends: ['./index.js', 'plugin:node/recommended'],
+  rules: {
+    strict: ['error', 'global'],
+    'node/exports-style': ['error', 'module.exports']
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "eslint-config-okonet",
   "version": "0.0.0-development",
   "description": "ESLint rules from Andrey Okonetchnikov",
-  "main": "index.js",
+  "files": [
+    "index.js",
+    "react.js",
+    "node.js"
+  ],
   "scripts": {
     "test": "npm run lint",
     "lint": "eslint .",
@@ -35,6 +39,7 @@
     "eslint-plugin-flowtype": "^2.19.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-react": "^7.3.0"
   },
@@ -50,6 +55,9 @@
     "prettier": "^1.5.3"
   },
   "eslintConfig": {
-    "extends": "./index.js"
+    "extends": "./node.js"
+  },
+  "engines": {
+    "node": ">= 4"
   }
 }

--- a/react.js
+++ b/react.js
@@ -1,0 +1,28 @@
+'use strict'
+
+module.exports = {
+  parser: 'babel-eslint',
+  parserOptions: {
+    sourceType: 'module'
+  },
+  env: {
+    browser: true,
+    commonjs: true
+  },
+  extends: ['./index.js', 'eslint-config-airbnb/rules/react', 'eslint-config-prettier/react'].map(
+    require.resolve
+  ),
+  rules: {
+    // React
+    'react/jsx-filename-extension': 0,
+    'react/sort-comp': [
+      2,
+      {
+        order: ['flow-types', 'static-methods', 'lifecycle', 'everything-else', 'render'],
+        groups: {
+          'flow-types': ['props', 'state']
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: Adding `"extends": "okonet"` will only add the basic config. See README