### PR TITLE
feat: Add install-peerdeps and made deps as peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
     "install-peerdeps": "^1.2.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "7.x",
     "eslint": "4.x",
-    "eslint-config-airbnb": "^15.1.0",
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-plugin-flowtype": "^2.19.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-node": "^5.1.1",
-    "eslint-plugin-prettier": "^2.0.1",
-    "eslint-plugin-react": "^7.3.0",
+    "eslint-config-airbnb": "15.x",
+    "eslint-config-prettier": "2.x",
+    "eslint-plugin-flowtype": "2.x",
+    "eslint-plugin-import": "2.x",
+    "eslint-plugin-jsx-a11y": "5.x",
+    "eslint-plugin-node": "5.x",
+    "eslint-plugin-prettier": "2.x",
+    "eslint-plugin-react": "7.x",
     "prettier": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node.js"
   ],
   "scripts": {
+    "postinstall": "install-peerdeps eslint-config-okonet --dev",
     "test": "npm run lint",
     "lint": "eslint .",
     "precommit": "lint-staged",
@@ -32,7 +33,11 @@
   },
   "homepage": "https://github.com/okonet/eslint-config-okonet#readme",
   "dependencies": {
+    "install-peerdeps": "^1.1.3"
+  },
+  "peerDependencies": {
     "babel-eslint": "^7.2.3",
+    "eslint": "4.x",
     "eslint-config-airbnb": "^15.1.0",
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-flowtype": "^2.19.0",
@@ -40,14 +45,15 @@
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.0.1",
-    "eslint-plugin-react": "^7.3.0"
-  },
-  "peerDependencies": {
-    "eslint": "4.x",
+    "eslint-plugin-react": "^7.3.0",
     "prettier": "*"
   },
   "devDependencies": {
-    "eslint": "^4.5.0",
+    "eslint": "^4.6.1",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.3.0",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.4",
     "npm-check": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node.js"
   ],
   "scripts": {
-    "postinstall": "install-peerdeps eslint-config-okonet --dev",
+    "postinstall": "install-peerdeps eslint-config-okonet --dev --only-peers",
     "test": "npm run lint",
     "lint": "eslint .",
     "precommit": "lint-staged",
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/okonet/eslint-config-okonet#readme",
   "dependencies": {
-    "install-peerdeps": "^1.1.3"
+    "install-peerdeps": "^1.2.0"
   },
   "peerDependencies": {
     "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -50,14 +50,10 @@
   },
   "devDependencies": {
     "eslint": "^4.6.1",
-    "eslint-config-airbnb": "^15.1.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.3.0",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.4",
     "npm-check": "^5.0.1",
-    "prettier": "^1.5.3"
+    "prettier": "^1.6.1"
   },
   "eslintConfig": {
     "extends": "./node.js"


### PR DESCRIPTION
This PR adds https://github.com/nathanhleung/install-peerdeps package to `postinstall` script and moves all `dependencies` to `peerDependencies`. This will ensure that after installation all needed dependencies will be installed automatically.

This is a workaround for https://github.com/eslint/eslint/issues/3458